### PR TITLE
FEAT: 웹소켓 관련 설정 추가

### DIFF
--- a/src/pages/coffeechat/CoffeeChatDetailPage.tsx
+++ b/src/pages/coffeechat/CoffeeChatDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState} from "react";
 import { useParams, useNavigate } from 'react-router-dom';
 import PageLayout from "@/layout/PageLayout";
 import { MapPin, Users } from "lucide-react";
@@ -6,6 +6,7 @@ import AlertModal from "@/components/common/AlertModal";
 import { IoChatbubblesOutline } from "react-icons/io5";
 import Icon from '@/assets/cute_coffee_favicon_128.ico'
 import MapBottomSheet from "@/components/coffeechat/MapBottomSheet";
+import { useWebSocketStore } from '@/stores/webSocketStore';
 
 export default function CoffeeChatDetailPage() {
   const { id } = useParams();
@@ -13,12 +14,17 @@ export default function CoffeeChatDetailPage() {
   const [joined, setJoined] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const { connect: connectWebSocket } = useWebSocketStore();
 
   const handleJoin = () => setModalOpen(true);
 
   const confirmJoin = () => {
     setJoined(true);
     setModalOpen(false);
+
+    if (id) {
+      connectWebSocket(id); // 현재 커피챗 ID로 연결 시도
+    }
   };
 
   return (

--- a/src/stores/webSocketStore.ts
+++ b/src/stores/webSocketStore.ts
@@ -1,0 +1,124 @@
+// src/stores/webSocketStore.ts
+
+import { create } from 'zustand';
+import SockJS from 'sockjs-client';
+import { Client, IMessage } from '@stomp/stompjs';
+
+// 채팅 메시지 타입 (필요한 경우 사용)
+interface ChatMessage {
+  messageId: string;
+  messageType: "TALK" | "JOIN" | "LEAVE";
+  content: string | null;
+  sentAt: string;
+  sender: { userId: string; name: string; profileImageUrl: string; };
+}
+
+// WebSocket 스토어의 상태 타입 정의
+interface WebSocketState {
+  stompClient: Client | null;
+  isConnected: boolean;
+  messages: ChatMessage[]; // 전역에서 채팅 메시지를 관리할 수도 있습니다.
+  currentCoffeechatId: string | null;
+
+  // 액션 함수들
+  connect: (coffeechatId: string) => void;
+  disconnect: () => void;
+  sendMessage: (destination: string, payload: any) => void; // 메시지 전송 함수
+  addMessage: (message: ChatMessage) => void; // 메시지 추가 함수
+  clearMessages: () => void; // 메시지 초기화 함수
+}
+
+export const useWebSocketStore = create<WebSocketState>((set, get) => ({
+  stompClient: null,
+  isConnected: false,
+  messages: [],
+  currentCoffeechatId: null, // 현재 연결된 커피챗 ID
+
+  connect: (coffeechatId: string) => {
+    const { stompClient, isConnected, currentCoffeechatId } = get();
+
+    // 이미 연결 중이고 같은 커피챗 ID면 다시 연결하지 않음
+    if (isConnected && currentCoffeechatId === coffeechatId) {
+      console.log('Zustand: Already connected to this coffeechat.');
+      return;
+    }
+
+    // 기존 연결이 있다면 해제
+    if (stompClient?.connected) {
+      console.log('Zustand: Disconnecting previous connection to connect to new coffeechat.');
+      stompClient.deactivate();
+      set({ isConnected: false, stompClient: null }); // 상태 초기화
+    }
+
+    set({ currentCoffeechatId: coffeechatId });
+    console.log(`Zustand: Attempting to connect to WebSocket for coffeechat ${coffeechatId}...`);
+
+    const socket = new SockJS(`http://${import.meta.env.VITE_API_BASE_URL}/ws`); // 또는 '/ws'
+
+    const client = new Client({
+      webSocketFactory: () => socket,
+      reconnectDelay: 5000,
+      heartbeatIncoming: 10000,
+      heartbeatOutgoing: 10000,
+      debug: (str) => console.log(new Date(), str), // 디버그 로그 추가
+
+      onConnect: (frame) => {
+        console.log('Zustand: Connected: ' + frame);
+        set({ isConnected: true, stompClient: client });
+
+        // 이 스토어에서 바로 구독을 관리할 수 있습니다.
+        // 하지만 구독은 해당 커피챗 ID에 따라 동적으로 이루어져야 하므로,
+        // 각 채팅방 컴포넌트에서 useWebSocketStore를 이용해 직접 구독하는 것이 더 유연합니다.
+        // 예를 들어: GroupChatPage의 useEffect에서 useWebSocketStore().stompClient를 가져와 구독.
+      },
+
+      onStompError: (frame) => {
+        console.error('Zustand: STOMP Error:', frame);
+        set({ isConnected: false, stompClient: null });
+      },
+      onWebSocketError: (event) => {
+        console.error('Zustand: WebSocket Error:', event);
+        set({ isConnected: false, stompClient: null });
+      },
+      onDisconnect: (frame) => {
+        console.log('Zustand: Disconnected:', frame);
+        set({ isConnected: false, stompClient: null, currentCoffeechatId: null });
+      }
+    });
+
+    client.activate(); // 연결 시작
+  },
+
+  disconnect: () => {
+    const { stompClient } = get();
+    if (stompClient?.connected) {
+      console.log('Zustand: Manual Disconnect initiated.');
+      stompClient.deactivate();
+      // deactivate()가 호출되면 onDisconnect 콜백이 실행되어 isConnected 상태가 업데이트됩니다.
+    } else {
+      console.log('Zustand: Not connected, no need to disconnect.');
+    }
+  },
+
+  sendMessage: (destination: string, payload: any) => {
+    const { stompClient, isConnected } = get();
+    if (stompClient && isConnected) {
+      stompClient.publish({
+        destination: destination,
+        body: JSON.stringify(payload),
+      });
+    } else {
+      console.warn('Zustand: Cannot send message, not connected.');
+    }
+  },
+
+  addMessage: (message: ChatMessage) => {
+    set((state) => ({
+      messages: [...state.messages, message]
+    }));
+  },
+
+  clearMessages: () => {
+    set({ messages: [] });
+  }
+}));


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- [x] CoffeeChatDetailPage에서 참여 버튼 누를 시 WebSocket upgrade header 요청 및 연결 진행하도록 구현.

## 🛠 변경사항

- Zustand에서 WebSocket 관련 상태 관리 CoffeeChatDetailPage에서 커피챗 참여 버튼 누를 시 WebSocket 연결 진행하도록 구현. 이전 구현에서는 연결 진행 후, 페이지가 unmount 됨에 따라 WebSocket 연결 또한 같이 해제된다는 문제가 존재했었습니다.

  해당 문제의 방지를 위해 Zustand를 통해 WebSocket 관련 부분을 전역으로 관리하도록 하여 페이지 이동 간에도 WebSocket 연결이 해제되지 않을 수 있도록 구현을 진행했습니다.

## 💬 리뷰 요구사항

- 현재 WebSocket 연결이 성공적으로 진행되는 것까지는 확인했습니다. BE에서도 메시지 수신 로그는 보이지만 화면 상에는 채팅 내역이 보이지 않습니다. 해당 부분에 대한 구현이 필요할 것 같습니다.

## 🔍 테스트 방법(선택)

- 로컬 환경에서 FE, BE 서버 띄운 후 테스트
