### PR TITLE
✨ feat: 커피챗 참여 목록/나가기 api 연동

### DIFF
--- a/src/api/coffeechat/coffeechatMemberApi.ts
+++ b/src/api/coffeechat/coffeechatMemberApi.ts
@@ -72,14 +72,14 @@ export const useJoinCoffeeChat = (coffeeChatId: string) => {
 };
 
 // ✅ DELETE 요청
-export const fetchExitCoffeeChat = async (memberId: string): Promise<void> => {
+export const fetchLeaveCoffeeChat = async (memberId: string): Promise<void> => {
     await apiClient.delete(`/api/v1/coffee-chats/members/${memberId}`);
   };
   
-export const useExitCoffeeChat = () => {
+export const useLeaveCoffeeChat = () => {
     const queryClient = useQueryClient();
     return createMutationHandler(
-        (memberId: string) => fetchExitCoffeeChat(memberId),
+        (memberId: string) => fetchLeaveCoffeeChat(memberId),
         {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["coffeeChats"] });

--- a/src/components/coffeechat/GroupMemberMenu.tsx
+++ b/src/components/coffeechat/GroupMemberMenu.tsx
@@ -1,0 +1,150 @@
+import { X, Home } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+export interface Member {
+  memberId: string;
+  chatNickname: string;
+  profileImageUrl: string;
+  isHost: boolean;
+}
+
+interface GroupMemberMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  members: Member[];
+  onLeave: () => void;
+  myMemberId: string;
+}
+
+const getInitial = (name: string) => name ? name[0] : '?';
+
+export default function GroupMemberMenu ({ isOpen, onClose, members, onLeave, myMemberId }: GroupMemberMenuProps) {
+  const navigate = useNavigate();
+
+  const goHome = () => {
+    navigate('/main/home');
+    onClose();
+  };
+
+  const host = members.find(m => m.isHost);
+  // 참여자 중 본인이 맨 위
+  const sortedMembers = members
+    .filter(m => !m.isHost)
+    .sort((a, b) => (a.memberId === myMemberId ? -1 : b.memberId === myMemberId ? 1 : 0));
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          onClick={onClose}
+          className="fixed inset-0 bg-black/50 z-40"
+        ></div>
+      )}
+      <div
+        className={`absolute top-0 right-0 bottom-0 z-50 transition-transform duration-300
+          w-[80%] flex flex-col
+        ${
+          isOpen ? 'translate-x-0' : 'translate-x-[110%]'
+        }`}
+        style={{
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        {/* 상단: 닫기 버튼 */}
+        <div
+          className="flex justify-between items-center p-4 border-b"
+          style={{
+            borderColor: '#E5E7EB',
+            backgroundColor: '#FE9400',
+          }}
+        >
+          <button onClick={goHome} className="p-1">
+            <Home size={20} className="text-white cursor-pointer" />
+          </button>
+          <button onClick={onClose} className="p-1">
+            <X size={20} className="text-white cursor-pointer" />
+          </button>
+        </div>
+
+        {/* 멤버 리스트 */}
+        <div className="flex-1 overflow-y-auto p-5">
+          <div className="mb-4 font-semibold text-lg text-[#333333]">대화상대</div>
+          <div className="space-y-6">
+            {/* 방장 영역 */}
+            <div>
+              <div className="w-full py-2 px-3 mb-2 rounded-sm bg-gray-100 font-semibold text-gray-800">방장</div>
+              <div className="flex items-center gap-3 px-3 py-3">
+                {/* 프로필 */}
+                {host ? (
+                  <div className="flex items-center gap-3">
+                    {host.profileImageUrl ? (
+                      <img
+                        src={host.profileImageUrl}
+                        alt={host.chatNickname}
+                        className="w-10 h-10 rounded-full object-cover bg-gray-200"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 flex items-center justify-center bg-indigo-400 text-white rounded-full font-bold text-xl">
+                        {getInitial(host.chatNickname)}
+                      </div>
+                    )}
+                    <span className="font-medium flex items-center gap-1">
+                      {host.chatNickname}
+                      {host.memberId === myMemberId && (
+                        <span className="ml-2 w-5 h-5 bg-amber-100 text-amber-600 text-xs font-semibold rounded-full flex items-center justify-center">
+                          나
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-sm text-gray-400">방장이 없습니다</span>
+                )}
+              </div>
+            </div>
+
+            {/* 참여자(멤버) 영역 */}
+            <div>
+              <div className="w-full py-2 px-3 mb-2 rounded-sm bg-gray-100 font-semibold text-gray-800">참여자</div>
+              <ul>
+                {sortedMembers.map((m) => (
+                  <li key={m.memberId} className="flex items-center gap-3 px-3 py-3">
+                    {m.profileImageUrl ? (
+                      <img
+                        src={m.profileImageUrl}
+                        alt={m.chatNickname}
+                        className="w-10 h-10 rounded-full object-cover bg-gray-200"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 flex items-center justify-center bg-indigo-400 text-white rounded-full font-bold text-xl">
+                        {getInitial(m.chatNickname)}
+                      </div>
+                    )}
+                    <span className="font-medium flex items-center gap-1">
+                      {m.chatNickname}
+                      {m.memberId === myMemberId && (
+                        <span className="ml-2 w-5 h-5 bg-amber-100 text-amber-600 text-xs font-semibold rounded-full flex items-center justify-center">
+                          나
+                        </span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {/* 하단: 나가기 버튼 (항상 아래 고정) */}
+        <div className="p-4">
+          <button
+            onClick={onLeave}
+            className="w-full py-3 rounded-sm bg-gray-100 text-red-500 font-semibold text-base hover:bg-gray-200 cursor-pointer"
+          >
+            커피챗 나가기
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/common/GNBMenu.tsx
+++ b/src/components/common/GNBMenu.tsx
@@ -1,6 +1,5 @@
 import { X, Home } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { VscAccount } from "react-icons/vsc";
 
 interface GNBMenuItem {
   label: string;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,14 +3,28 @@ import { Menu, ChevronLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import GNBMenu from '@/components/common/GNBMenu';
 import Logo from '@/assets/logo.svg';
+import GroupMemberMenu, { Member } from '@/components/coffeechat/GroupMemberMenu';
 
 interface HeaderProps {
   mode: 'logo' | 'title';
   title?: string;
   onBackClick?: () => void;
+  isGroupChat?: boolean;    
+  chatMembers?: Member[];     
+  onLeaveChat?: () => void; 
+  myMemberId?: string 
 }
 
-const Header = ({ mode, title, onBackClick }: HeaderProps) => {
+
+const Header = ({
+  mode,
+  title,
+  onBackClick,
+  isGroupChat = false,   
+  chatMembers,
+  onLeaveChat,
+  myMemberId,
+}: HeaderProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -76,11 +90,21 @@ const Header = ({ mode, title, onBackClick }: HeaderProps) => {
       </header>
 
       {/* GNB 메뉴 컴포넌트 */}
-      <GNBMenu
-        isOpen={isMenuOpen}
-        onClose={() => setIsMenuOpen(false)}
-        items={menuItems}
-      />
+      {isGroupChat ? (
+        <GroupMemberMenu
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+          members={chatMembers || []}
+          onLeave={onLeaveChat || (() => {})}
+          myMemberId={myMemberId || ""}
+        />
+      ) : (
+        <GNBMenu
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+          items={menuItems}
+        />
+      )}
     </>
   );
 };

--- a/src/layout/PageLayout.tsx
+++ b/src/layout/PageLayout.tsx
@@ -1,11 +1,16 @@
 import Header from '@/components/common/Header';
 import FABContainer from "@/components/common/FABContainer";
+import { Member } from '@/components/coffeechat/GroupMemberMenu';
 
 interface PageLayoutProps {
   children: React.ReactNode;
   headerMode?: 'logo' | 'title';
   headerTitle?: string;
   onBackClick?: () => void;
+  isGroupChat?: boolean;
+  chatMembers?: Member[];
+  onLeaveChat?: () => void;
+  myMemberId?: string;
   mainClassName?: string;
   mainRef?: React.RefObject<HTMLDivElement>;
 
@@ -28,10 +33,23 @@ export default function PageLayout({
   showAdd,
   onMainClick,
   onAddClick,
+
+  isGroupChat,
+  chatMembers,
+  onLeaveChat,
+  myMemberId,
 }: PageLayoutProps) {
   return (
     <div className="flex flex-col h-full">
-      <Header mode={headerMode} title={headerTitle} onBackClick={onBackClick} />
+    <Header
+      mode={headerMode}
+      title={headerTitle}
+      onBackClick={onBackClick}
+      isGroupChat={isGroupChat}         
+      chatMembers={chatMembers}      
+      onLeaveChat={onLeaveChat} 
+      myMemberId={myMemberId}         
+    />
 
       <main
         id="scroll-container"

--- a/src/pages/coffeechat/GroupChatPage.tsx
+++ b/src/pages/coffeechat/GroupChatPage.tsx
@@ -4,8 +4,7 @@ import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { FaArrowUp } from "react-icons/fa6";
 import { Client, IMessage } from "@stomp/stompjs";
 import { useWebSocketStore } from "@/stores/webSocketStore";
-import { useCoffeeChatMembership } from "@/api/coffeechat/coffeechatMemberApi";
-import { CodeSquare } from "lucide-react";
+import { useCoffeeChatMembers, useCoffeeChatMembership, useLeaveCoffeeChat } from "@/api/coffeechat/coffeechatMemberApi";
 
 interface Sender {
   userId: string;
@@ -34,6 +33,8 @@ export default function GroupChatPage() {
   const { connect, disconnect, sendMessage, addMessage, stompClient } = useWebSocketStore();
   const [connectionStatus, setConnectionStatus] = useState<"connecting" | "connected" | "disconnected">("disconnected");
   const { data: membership, isLoading: isMembershipLoading, isError: isMembershipError, error: membershipError, refetch: refetchMembership } = useCoffeeChatMembership(coffeechatId ?? "");
+  const { data: members, isLoading: isMembersLoading } = useCoffeeChatMembers(coffeechatId ?? "");
+  const { mutateAsyncFn: leaveChat, isLoading: isLeaving } = useLeaveCoffeeChat();
 
   useEffect(() => {
     if (memberId) return;
@@ -118,6 +119,24 @@ export default function GroupChatPage() {
     setInput("");
   };
 
+  // 채팅방 나가기
+  const handleLeaveChat = async () => {
+    if (!memberId) {
+      alert("멤버 정보를 찾을 수 없습니다.");
+      return;
+    }
+    try {
+      await leaveChat(memberId);
+      navigate("/main/coffeechat");
+    } catch (err: any) {
+      alert(
+        err?.message ||
+        err?.data?.message ||
+        "나가기 중 오류가 발생했습니다."
+      );
+    }
+  };
+
   // 🧽 자동 스크롤
   useEffect(() => {
     chatBoxRef.current?.scrollTo({ top: chatBoxRef.current.scrollHeight, behavior: "smooth" });
@@ -133,6 +152,10 @@ export default function GroupChatPage() {
       headerMode="title"
       headerTitle="그룹 채팅방"
       onBackClick={() => navigate(`/main/coffeechat/${coffeechatId}`)}
+      isGroupChat={true}
+      chatMembers={members?.members ?? []}  
+      onLeaveChat={handleLeaveChat}
+      myMemberId={memberId ?? ""}
     >
       <div className="flex flex-col h-[calc(100dvh-64px)] bg-gray-50">
         {/* 연결 상태 표시 */}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- 커피챗 참여 목록 api와 나가기 api 컴포넌트와 연
- 커피챗 햄버거 메뉴 UI 구현 

## 🛠 변경사항

- header의 햄버거 메뉴 열림 상태를 gnb와 chatting으로 분류
- `PageLayout.tsx`와 `header.tsx`에 해당 props 반영

## 💬 리뷰 요구사항

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 🔍 테스트 방법(선택)

- 브라우저 화면으로 구현 확인
- 커피챗 나가기 (500 에러 발생) - 추후 테스트 필요
![image](https://github.com/user-attachments/assets/08e59f1f-0cb3-4557-bf3f-6af53fcf817b)

