### PR TITLE
🐛 fix: 채팅 메시지 렌더링 버그 수정

### DIFF
--- a/src/api/coffeechat/coffeechat.dto.ts
+++ b/src/api/coffeechat/coffeechat.dto.ts
@@ -133,7 +133,7 @@ export interface ChatMessage {
         chatNickname: string;
         profileImageUrl: string;
     };
-    messageType?: "TALK" | "JOIN" | "LEAVE";
+    messageType?: "TALK" | "ENTER" | "LEAVE";
 }
 
 

--- a/src/api/coffeechat/coffeechatMessageApi.ts
+++ b/src/api/coffeechat/coffeechatMessageApi.ts
@@ -1,5 +1,5 @@
 import apiClient from "@/api/apiClient";
-import { ChatMessage, CoffeeChatMessagesResponse } from "@/api/coffeechat/coffeechat.dto";
+import { CoffeeChatMessagesResponse } from "@/api/coffeechat/coffeechat.dto";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 export const fetchCoffeeChatMessages = async (
@@ -34,14 +34,15 @@ export const fetchCoffeeChatMessages = async (
       // ✅ 요청 함수
       queryFn: ({ pageParam }) =>
         fetchCoffeeChatMessages(coffeeChatId, pageParam as string, limit, order),
+
+      getNextPageParam: () => undefined,
   
       // ✅ 다음 커서 설정
-      getNextPageParam: (lastPage) =>
-        lastPage.hasNext ? lastPage.nextCursor : undefined,
+      getPreviousPageParam: (firstPage) =>
+        firstPage.hasNext ? firstPage.nextCursor : undefined,
 
       refetchOnMount: "always",
       refetchOnWindowFocus: true,
-  
       enabled: !!coffeeChatId,
     });
   };

--- a/src/components/coffeechat/ChatMessages.tsx
+++ b/src/components/coffeechat/ChatMessages.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useInfiniteCoffeeChatMessages } from "@/api/coffeechat/coffeechatMessageApi";
+import { CoffeeChatMessagesResponse } from "@/api/coffeechat/coffeechat.dto";
 import type { ChatMessage } from "@/api/coffeechat/coffeechat.dto";
 
 interface ChatMessagesProps {
@@ -11,38 +12,50 @@ interface ChatMessagesProps {
 export default function ChatMessages({ coffeeChatId, memberId, realtimeMessages }: ChatMessagesProps) {
   const {
     data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
+    fetchPreviousPage,
+    hasPreviousPage,
+    isFetchingPreviousPage,
   } = useInfiniteCoffeeChatMessages(coffeeChatId);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const loadTriggerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const previousScrollHeightRef = useRef<number>(0);
 
-  // ✅ 메시지 병합 로직
+  // 메시지 세팅
   useEffect(() => {
-    const initialMessages = data?.pages.flatMap((page) => page.messages) ?? [];
-    setMessages([...initialMessages]);
-  }, [data]);
+    if (!data || data.pages.length === 0) return;
+  
+    const lastPage = data.pages[data.pages.length - 1]; 
+    const newMessages = (lastPage as CoffeeChatMessagesResponse).messages ?? [];
+  
+    setMessages((prev) => {
+      const existingIds = new Set(prev.map((m) => m.messageId));
+      const uniqueNew = newMessages.filter((m) => !existingIds.has(m.messageId));
+      return [...uniqueNew, ...prev]; // 앞에만 추가
+    });
+  }, [data?.pages.length]); 
 
-  // ✅ 실시간 메시지 오면 뒤에 추가
+  // 실시간 메시지 병합 (중복 제거)
   useEffect(() => {
-    if (realtimeMessages.length > 0) {
-      setMessages((prev) => [...prev, ...realtimeMessages]);
-    }
+    if (realtimeMessages.length === 0) return;
+    setMessages((prev) => {
+      const existingIds = new Set(prev.map((m) => m.messageId));
+      const newMessages = realtimeMessages.filter((m) => !existingIds.has(m.messageId));
+      return [...prev, ...newMessages];
+    });
   }, [realtimeMessages]);
 
-  // ✅ 무한 스크롤 (과거 메시지)
+  // 무한 스크롤 로딩 트리거
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+        const entry = entries[0];
+        const scrollTop = scrollRef.current?.scrollTop ?? 0;
+        if (entry.isIntersecting && hasPreviousPage && !isFetchingPreviousPage && scrollTop <= 50) {
           previousScrollHeightRef.current = scrollRef.current?.scrollHeight || 0;
-          fetchNextPage();
+          fetchPreviousPage();
         }
       },
       {
@@ -50,24 +63,23 @@ export default function ChatMessages({ coffeeChatId, memberId, realtimeMessages 
         threshold: 1.0,
       }
     );
-
+  
     const el = loadTriggerRef.current;
     if (el) observer.observe(el);
-
     return () => {
       if (el) observer.unobserve(el);
     };
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage]);
 
-  // ✅ 과거 메시지 스크롤 유지
+  // 과거 메시지 로딩 후 스크롤 위치 유지
   useEffect(() => {
-    if (!isFetchingNextPage && scrollRef.current) {
+    if (!isFetchingPreviousPage && scrollRef.current) {
       const diff = scrollRef.current.scrollHeight - previousScrollHeightRef.current;
       scrollRef.current.scrollTop += diff;
     }
   }, [data]);
 
-  // ✅ 최초 로딩 시 맨 아래로 이동
+  // 초기 로딩 시 맨 아래로 스크롤
   useEffect(() => {
     if (data && bottomRef.current) {
       bottomRef.current.scrollIntoView({ behavior: "auto" });
@@ -84,32 +96,26 @@ export default function ChatMessages({ coffeeChatId, memberId, realtimeMessages 
   return (
     <div
       ref={scrollRef}
-      className="flex-1 overflow-y-auto px-4 pb-36 flex flex-col space-y-3"
+      className="flex-1 overflow-y-auto px-4 pb-36 flex flex-col justify-end space-y-3"
     >
       <div ref={loadTriggerRef} />
 
       {messages.map((msg) => {
-        const type = msg.messageType ?? "TALK";
+        const isMine = msg.sender.memberId === memberId;
+        const isSystem = msg.messageType === "ENTER" || msg.messageType === "LEAVE";
 
-        if (type === "JOIN" || type === "LEAVE") {
+        if (isSystem) {
           return (
             <div key={msg.messageId} className="text-center text-sm text-gray-400">
-              {msg.sender.chatNickname}님이 {type === "JOIN" ? "입장" : "퇴장"}하셨습니다.
+              {msg.sender.chatNickname}님이 {msg.messageType === "ENTER" ? "입장" : "퇴장"}하셨습니다.
             </div>
           );
         }
 
-        const isMine = msg.sender.memberId === memberId;
-
         return (
-          <div
-            key={msg.messageId}
-            className={`w-full ${isMine ? "flex justify-end" : "flex justify-start"}`}
-          >
+          <div key={msg.messageId} className={`w-full ${isMine ? "flex justify-end" : "flex justify-start"}`}>
             <div className={`flex flex-col ${isMine ? "items-end" : "items-start"} max-w-[80%]`}>
-              {!isMine && (
-                <div className="text-sm text-gray-600 mb-1">{msg.sender.chatNickname}</div>
-              )}
+              {!isMine && <div className="text-sm text-gray-600 mb-1">{msg.sender.chatNickname}</div>}
               <div className={`flex items-end gap-1 ${isMine ? "flex-row-reverse" : "flex-row"}`}>
                 <div
                   className={`px-4 py-2 rounded-2xl text-sm shadow max-w-xs whitespace-pre-wrap break-words ${
@@ -129,7 +135,7 @@ export default function ChatMessages({ coffeeChatId, memberId, realtimeMessages 
         );
       })}
 
-      {isFetchingNextPage && (
+      {isFetchingPreviousPage && (
         <div className="text-center text-gray-400 py-2 text-sm">불러오는 중...</div>
       )}
 

--- a/src/layout/PageLayout.tsx
+++ b/src/layout/PageLayout.tsx
@@ -59,7 +59,7 @@ export default function PageLayout({
       <main
         id="scroll-container"
         ref={mainRef}
-        className={`mt-16 scrollbar-hide pb-8 ${headerMode === 'title' ? 'px-2' : ''} ${nonScrollClassName ? '' : 'overflow-y-auto'}`}
+        className={`mt-16 scrollbar-hide pb-8 ${headerMode === 'title' ? 'px-2' : ''} ${nonScrollClassName ? '!pb-0' : 'overflow-y-auto'}`}
       
       >
         <div id="observer-target" className="h-[1px] w-full opacity-0 pointer-events-none" />

--- a/src/pages/coffeechat/CoffeeChatDetailPage.tsx
+++ b/src/pages/coffeechat/CoffeeChatDetailPage.tsx
@@ -39,7 +39,7 @@ export default function CoffeeChatDetailPage() {
         senderId: result.memberId,
         coffeechatId: id,
         message: `${chatNickname}님이 입장했습니다`,
-        type: "JOIN",
+        type: "ENTER",
       });
 
       // 바로 해제
@@ -51,14 +51,13 @@ export default function CoffeeChatDetailPage() {
       setJoinModalOpen(false);
     } catch (error: any) {
       console.error("커피챗 참여 오류:" + `${error.status}(${error.code}) - ${error.message}`);
-      setAlertMessage(error.message || "카페인 등록에 실패했습니다.");
+      setAlertMessage(error.message || "커피챗 참여 오류에 실패했습니다.");
       setJoinModalOpen(false);
       setIsAlertOpen(true);  
     }
   };
 
   // 채팅하기 버튼
-
   const handleEnterChatRoom = async () => {
     try {
       const { data: freshMembership } = await refetchMembership();
@@ -69,7 +68,6 @@ export default function CoffeeChatDetailPage() {
       }
       navigate(`/main/coffeechat/${id}/chat`, {
         state: {
-          userId: membershipData.userId,
           memberId: membershipData.memberId,
         },
       });


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- 채팅 메시지 무한 스크롤 구현
-  이전 메시지 → 스크롤 시 앞에만 추가
- 실시간 메시지 → 뒤에만 추가
- 중복 없이, 불필요한 re-render 없이, 정확한 동작 구현
- 버그 수정 

## 🛠 변경사항

- `JOIN` -> `ENTER`
-  `getNextPageParam` -> `getPreviousPageParam`
- 현재 설정(한 번에 20개씩)이라 한 번에 한 페이지만 불러옴: flatMap 없애고 페이지 순서로 구현
 
## 💬 리뷰 요구사항

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 🔍 테스트 방법(선택)

- 백엔드와 테스트 예정
