### PR TITLE
🐛 fix: 커피챗 참여 시, 기본 프로필 참여 오류 수정

### DIFF
--- a/src/api/coffeechat/coffeechat.dto.ts
+++ b/src/api/coffeechat/coffeechat.dto.ts
@@ -60,7 +60,7 @@ export interface CoffeeChatDetailResponseDTO {
 
 export interface JoinCoffeeChatRequestDTO {
     chatNickname: string;
-    profileType: "DEFAULT" | "USER";
+    profileImageType: "DEFAULT" | "USER";
 }
 
 export interface JoinCoffeeChatResponseDTO {

--- a/src/components/coffeechat/JoinCoffeeChatModal.tsx
+++ b/src/components/coffeechat/JoinCoffeeChatModal.tsx
@@ -5,7 +5,7 @@ import { limitLength } from "@/utils/inputUtils";
 interface JoinCoffeeChatModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (params: { chatNickname: string; profileType: "DEFAULT" | "USER" }) => void;
+  onSubmit: (params: { chatNickname: string; profileImageType: "DEFAULT" | "USER" }) => void;
   defaultProfileType?: "DEFAULT" | "USER";
 }
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- [x] 커피챗 참여 요청 시 `profileType` → `profileImageType`으로 필드명 수정

## 🛠 변경사항

- 요청 dto 필드 수정
- 요청 호출부 수정

## 💬 리뷰 요구사항

- 확인부탁드립니다

