### PR TITLE
[PERFORMANCE] 이미지 최적화 2단계: 최적 포맷(업로드 리사이징)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tanstack/react-query": "5.28.0",
     "axios": "1.6.8",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "connect-history-api-fallback": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       axios:
         specifier: 1.6.8
         version: 1.6.8
+      browser-image-compression:
+        specifier: ^2.0.2
+        version: 2.0.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -133,7 +136,7 @@ importers:
         version: 3.3.0
       ui:
         specifier: git+https://github.com/shadcn/ui.git
-        version: git+https://github.com/shadcn/ui.git#f85ca066dcf488257ab9f8b349c1075a40552185(@types/node@24.0.14)(@vitest/browser@3.1.4)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+        version: git+https://github.com/shadcn/ui.git#a9ab05ad83b46e5387c6657f9324edfb9f98a9e5(@types/node@24.0.14)(@vitest/browser@3.1.4)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2673,6 +2676,9 @@ packages:
 
   browser-assert@1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
+
+  browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
 
   browserslist@4.25.0:
     resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
@@ -5750,8 +5756,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ui@git+https://github.com/shadcn/ui.git#f85ca066dcf488257ab9f8b349c1075a40552185:
-    resolution: {commit: f85ca066dcf488257ab9f8b349c1075a40552185, repo: https://github.com/shadcn/ui.git, type: git}
+  ui@git+https://github.com/shadcn/ui.git#a9ab05ad83b46e5387c6657f9324edfb9f98a9e5:
+    resolution: {commit: a9ab05ad83b46e5387c6657f9324edfb9f98a9e5, repo: https://github.com/shadcn/ui.git, type: git}
     version: 0.0.1
 
   unbox-primitive@1.1.0:
@@ -5827,6 +5833,9 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -6465,7 +6474,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@types/node@24.0.14)(typescript@5.4.5))(typescript@5.4.5)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -8640,6 +8649,10 @@ snapshots:
 
   browser-assert@1.2.1: {}
 
+  browser-image-compression@2.0.2:
+    dependencies:
+      uzip: 0.20201231.0
+
   browserslist@4.25.0:
     dependencies:
       caniuse-lite: 1.0.30001720
@@ -8837,7 +8850,7 @@ snapshots:
 
   cookie@1.0.2: {}
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@types/node@24.0.14)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -11963,7 +11976,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  ui@git+https://github.com/shadcn/ui.git#f85ca066dcf488257ab9f8b349c1075a40552185(@types/node@24.0.14)(@vitest/browser@3.1.4)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
+  ui@git+https://github.com/shadcn/ui.git#a9ab05ad83b46e5387c6657f9324edfb9f98a9e5(@types/node@24.0.14)(@vitest/browser@3.1.4)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       '@babel/core': 7.27.3
       '@changesets/changelog-github': 0.4.8
@@ -12117,6 +12130,8 @@ snapshots:
       which-typed-array: 1.1.19
 
   uuid@9.0.1: {}
+
+  uzip@0.20201231.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -126,7 +126,7 @@ export default function Header ({
                             alt="프로필"
                             width={size?.width ?? 28}
                             height={size?.height ?? 28}
-                            className="w-7 h-7 rounded-full bg-gray-100"
+                            className="w-7 h-7 rounded-full bg-gray-100 object-cover"
                           />
                         ) : (
                           <div className="w-7 h-7 rounded-full bg-gray-300" />

--- a/src/components/review/WriteReviewForm.tsx
+++ b/src/components/review/WriteReviewForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { Camera, X, Clock, MapPin, CalendarIcon, Edit, Hash } from 'lucide-react';
 import { useToastStore } from '@/stores/toastStore';
+import imageCompression from 'browser-image-compression';
 
 interface UploadedImage {
   id: string;
@@ -38,38 +39,43 @@ export default function WriteReviewForm({
   const showToast = useToastStore((state) => state.showToast);
   const maxLength = 150;
 
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files) return;
-  
+
     const MAX_COUNT = 3;
     const MAX_SIZE_MB = 5;
-  
+
     const fileArray = Array.from(files);
     const remainingSlots = MAX_COUNT - images.length;
-  
+
     const validFiles = fileArray.slice(0, remainingSlots).filter((file) => {
       if (!file.type.startsWith('image/')) return false;
-  
+
       if (file.size > MAX_SIZE_MB * 1024 * 1024) {
         showToast('error', '사진은 5MB 이하만 업로드 가능합니다.');
         return false;
       }
-  
       return true;
     });
-  
-    validFiles.forEach((file) => {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const preview = e.target?.result as string;
-  
-        // 이미지 크기 알아내기
+
+    for (const file of validFiles) {
+      try {
+        const options = {
+          maxSizeMB: 1,
+          maxWidthOrHeight: 1024,
+          useWebWorker: true,
+          initialQuality: 0.8,
+        };
+
+        const compressedFile = await imageCompression(file, options);
+        const preview = URL.createObjectURL(compressedFile);
+
         const img = new Image();
         img.onload = () => {
           const newImage: UploadedImage = {
             id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
-            file,
+            file: compressedFile,
             preview,
             width: img.naturalWidth,
             height: img.naturalHeight,
@@ -77,15 +83,16 @@ export default function WriteReviewForm({
           setImages((prev) => [...prev, newImage]);
         };
         img.src = preview;
-      };
-      reader.readAsDataURL(file);
-    });
-  
+      } catch (error) {
+        console.error('이미지 압축 실패:', error);
+        showToast('error', '이미지 압축에 실패했습니다.');
+      }
+    }
+
     if (event.target) {
       event.target.value = '';
     }
   };
-  
 
   const removeImage = (imageId: string) => {
     setImages((prev) => prev.filter((img) => img.id !== imageId));

--- a/src/pages/mypage/mypage/MyPageContainer.tsx
+++ b/src/pages/mypage/mypage/MyPageContainer.tsx
@@ -66,13 +66,10 @@ export default function MyPageContainer() {
         showToast('error', '지원하지 않는 이미지 형식입니다.');
         return;
       }
-
-      console.log('📏 압축 전 이미지 크기:', (file.size / 1024).toFixed(2), 'KB');
       setIsCompressing(true);
 
       try {
         const compressedFile = await compressImage(file, 0.3, 1024, 0.9);
-        console.log('📉 압축 후 이미지 크기:', (compressedFile.size / 1024).toFixed(2), 'KB');
 
         const previewUrl = URL.createObjectURL(compressedFile);
         setEditProfileImageUrl(previewUrl);

--- a/src/pages/mypage/mypage/MyPageUI.tsx
+++ b/src/pages/mypage/mypage/MyPageUI.tsx
@@ -49,6 +49,7 @@ interface MyPageUIProps {
   setEditNickname: (name: string) => void;
   editProfileImageUrl: string;
   setEditProfileImageUrl: (url: string) => void;
+  isCompressing: boolean;
   navigate: any;
 }
 
@@ -62,6 +63,7 @@ const MyPageUI: React.FC<MyPageUIProps> = ({
   setEditNickname,
   editProfileImageUrl,
   setEditProfileImageUrl,
+  isCompressing,
   navigate,
 }) => {
   const {
@@ -183,6 +185,11 @@ const MyPageUI: React.FC<MyPageUIProps> = ({
                 className="hidden"
                 onChange={onProfileImageChange}
               />
+              {isCompressing && (
+                <div className="absolute inset-0 flex items-center justify-center bg-white/80 rounded-full z-50">
+                  <LoadingSpinner fullScreen={false} size="medium" type="clip" />
+                </div>
+              )}
             </div>
 
             <input

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -12,6 +12,7 @@ export async function compressImage(
     useWebWorker: true,
     maxIteration: 10,
     initialQuality,
+    fileType: 'image/webp',
   };
 
   try {

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -1,0 +1,24 @@
+import imageCompression from 'browser-image-compression';
+
+export async function compressImage(
+  file: File,
+  maxSizeMB = 1,
+  maxWidthOrHeight = 128,
+  initialQuality = 0.9
+): Promise<File> {
+  const options = {
+    maxSizeMB,
+    maxWidthOrHeight,
+    useWebWorker: true,
+    maxIteration: 10,
+    initialQuality,
+  };
+
+  try {
+    const compressedFile = await imageCompression(file, options);
+    return compressedFile;
+  } catch (error) {
+    console.error('이미지 압축 실패:', error);
+    throw error;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,4 +26,7 @@ export default defineConfig({
     global: 'globalThis',
   },
   assetsInclude: ['**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.webp', '**/*.avif'],
+  optimizeDeps: {
+    include: ['browser-image-compression'],
+  },
 });


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- [x] 클라이언트에서 업로드하는 프로필 이미지 리사이징
- [x] 클라이언트에서 업로드하는 후기 이미지 리사이징
- [x] 압축 + 포맷(webp)로 이미지 최적화

## 🛠 변경사항

- `brower-image-compression` 라이브러리 사용
- 프로필, 후기 이미지 업로드 시 `compressImage.ts`로 이미지 최적화 진행

## 💬 리뷰 요구사항

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 🔍 테스트 방법(선택)

- network 탭에서 이미지 size 줄어들고 type이 webp로 되어있음을 확인
<img width="1609" height="43" alt="image" src="https://github.com/user-attachments/assets/090b584c-2333-49ad-81ea-01837ab1f32f" />
